### PR TITLE
Add protected tags feature to prevent deletion of specific tags in GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Expire (delete) tags from container registry ghcr.io on a specific timeset (30 days)
 
-hint: requires a Personal access token with skope: delete:packages, repo, write:packages
+hint: requires a Personal access token with scope: delete:packages, repo, write:packages
 
-usage:
+## Usage
 
-for user:
+### For user:
 
-```
+```yaml
 on:
   schedule:
     - cron: "10 6 * * *"
@@ -26,11 +26,12 @@ jobs:
           repo_type: user
           image_name: myimage
           days_treshold: 100
+          protected_tags: latest,dev
 ```
 
-for org:
+### For org:
 
-```
+```yaml
 on:
   schedule:
     - cron: "10 6 * * *"
@@ -49,14 +50,16 @@ jobs:
           orgname: my-org
           image_name: myapp%2Fmyimage
           days_treshold: 100
+          protected_tags: latest,dev
 ```
 
-inputs:
+## Inputs
 
-| Parameter      | Description                                             |
-|----------------|---------------------------------------------------------|
-| `token`        | The Personal Access Token with the required scopes.     |
-| `repo_type`    | The type of repository (`user` or `org`).               |
-| `orgname`      | The name of the organization (only for `org` repo_type).|
-| `image_name`   | The name of the container image.                        |
-| `days_treshold`| The number of days after which tags will be expired.    |
+| Parameter       | Description                                             |
+|-----------------|---------------------------------------------------------|
+| `token`         | The Personal Access Token with the required scopes.     |
+| `repo_type`     | The type of repository (`user` or `org`).               |
+| `orgname`       | The name of the organization (only for `org` repo_type).|
+| `image_name`    | The name of the container image.                        |
+| `days_treshold` | The number of days after which tags will be expired.    |
+| `protected_tags`| Comma-separated list of tags that should not be deleted.|

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,10 @@ inputs:
     required: false
     type: int
     default: 30
+  protected_tags:
+    required: false
+    type: string
+    default: ""
   orgname:
     required: false
     type: string
@@ -52,5 +56,5 @@ runs:
       shell: bash
        
     - name: "Run tagexpire"
-      run: "./venv/bin/python tagexpire.py ${{ inputs.token }} ${{ inputs.repo_type }} ${{ inputs.image_name }} ${{ inputs.days_treshold }} ${{ inputs.orgname }}" 
+      run: "./venv/bin/python tagexpire.py ${{ inputs.token }} ${{ inputs.repo_type }} ${{ inputs.image_name }} ${{ inputs.days_treshold }} ${{ inputs.protected_tags }} ${{ inputs.orgname }}" 
       shell: bash

--- a/tagexpire.py
+++ b/tagexpire.py
@@ -5,12 +5,13 @@ import json
 import math
 import sys
 
-# define command line arguments username, token, image_name, days_threshold, orgname
+# Define command line arguments: username, token, repo_type, image_name, days_threshold, protected_tags, orgname
 token = sys.argv[1]
 repo_type = sys.argv[2]
 image_name = sys.argv[3]
 days_threshold = int(sys.argv[4])
-orgname = sys.argv[5] if len(sys.argv) > 5 else None
+protected_tags = sys.argv[5].split(',') if len(sys.argv) > 5 else []
+orgname = sys.argv[6] if len(sys.argv) > 6 else None
 
 # Token for authentication
 authheader = {'Authorization': 'Bearer ' + token}
@@ -32,7 +33,7 @@ if repo_type == 'user':
             tags = response.json()
             for tag in tags:
                 created_at = datetime.strptime(tag['created_at'], '%Y-%m-%dT%H:%M:%SZ')
-                if created_at < threshold_date:
+                if created_at < threshold_date and tag['name'] not in protected_tags:
                     print(f'Delete tag {tag["id"]} - {tag["name"]}')
                     try:
                         response = requests.delete(f'https://api.github.com/user/packages/container/{image_name}/versions/{tag["id"]}', headers=authheader)
@@ -67,7 +68,7 @@ elif repo_type == 'org':
             tags = response.json()
             for tag in tags:
                 created_at = datetime.strptime(tag['created_at'], '%Y-%m-%dT%H:%M:%SZ')
-                if created_at < threshold_date:
+                if created_at < threshold_date and tag['name'] not in protected_tags:
                     print(f'Delete tag {tag["id"]} - {tag["name"]}')
                     try:
                         response = requests.delete(f'https://api.github.com/orgs/{orgname}/packages/container/{image_name}/versions/{tag["id"]}', headers=authheader)


### PR DESCRIPTION
## Motivation

This change aims to introduce a feature that allows users to specify certain image tags that should not be deleted by the GitHub Action, even if they are older than the specified threshold. This is important for preserving crucial tags such as `latest` or `dev` that should remain available regardless of their age.

## Changes

- Updated `tagexpire.py` to include a `protected_tags` parameter.
- Modified the deletion logic to skip tags specified in the `protected_tags` list.
- Updated `action.yaml` to include `protected_tags` as an input parameter.
- Added relevant examples and descriptions in the `README.md` to guide users on how to use the new feature.